### PR TITLE
53 Bug: Strict mode rejects encrypted bitcoin address lookups even when the decryption secret is provided

### DIFF
--- a/Branta.Tests/V2/Services/BrantaServiceTests.cs
+++ b/Branta.Tests/V2/Services/BrantaServiceTests.cs
@@ -695,6 +695,58 @@ public class BrantaServiceTests
     }
 
     [Fact]
+    public async Task GetPaymentsAsync_StrictMode_EncryptedBitcoinAddress_WithSecret_DecryptsDestination()
+    {
+        _clientMock
+            .Setup(c => c.GetPaymentsAsync(EncryptedBitcoinAddress, It.IsAny<BrantaClientOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([ZkBitcoinPayment]);
+
+        var result = await _strictService.GetPaymentsAsync(EncryptedBitcoinAddress, destinationEncryptionKey: Secret);
+
+        Assert.Single(result.Payments);
+        Assert.Equal(BitcoinAddress, result.Payments[0].Destinations[0].Value);
+        Assert.False(result.Payments[0].Destinations[0].IsEncrypted);
+        _clientMock.Verify(c => c.GetPaymentsAsync(EncryptedBitcoinAddress, It.IsAny<BrantaClientOptions?>(), It.IsAny<CancellationToken>()), Times.Once);
+        _aesEncryptionMock.Verify(e => e.Decrypt(EncryptedBitcoinAddress, Secret), Times.Once);
+        _aesEncryptionMock.Verify(e => e.Encrypt(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPaymentsAsync_StrictMode_EncryptedBitcoinAddress_WithSecret_SetsVerifyUrlWithKeyFragment()
+    {
+        var payment = new PaymentBuilder()
+            .AddDestination(EncryptedBitcoinAddress, type: DestinationType.BitcoinAddress)
+            .SetZk()
+            .Build();
+        var zkId = payment.Destinations[0].ZkId!;
+
+        _clientMock
+            .Setup(c => c.GetPaymentsAsync(EncryptedBitcoinAddress, It.IsAny<BrantaClientOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([payment]);
+
+        var result = await _strictService.GetPaymentsAsync(EncryptedBitcoinAddress, destinationEncryptionKey: Secret);
+
+        Assert.Equal($"http://localhost:3000/v2/verify/{EncryptedBitcoinAddress}#k-{zkId}={Secret}", result.VerifyUrl);
+    }
+
+    [Fact]
+    public async Task GetPaymentsAsync_StrictMode_EncryptedBitcoinAddress_WrongKey_LeavesEncrypted()
+    {
+        _clientMock
+            .Setup(c => c.GetPaymentsAsync(EncryptedBitcoinAddress, It.IsAny<BrantaClientOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([ZkBitcoinPayment]);
+        _aesEncryptionMock
+            .Setup(e => e.Decrypt(EncryptedBitcoinAddress, "wrong-key"))
+            .Throws(new Exception("Decryption failed: auth tag mismatch"));
+
+        var result = await _strictService.GetPaymentsAsync(EncryptedBitcoinAddress, destinationEncryptionKey: "wrong-key");
+
+        Assert.Single(result.Payments);
+        Assert.Equal(EncryptedBitcoinAddress, result.Payments[0].Destinations[0].Value);
+        Assert.True(result.Payments[0].Destinations[0].IsEncrypted);
+    }
+
+    [Fact]
     public async Task GetPaymentsAsync_StrictMode_Bolt11Invoice_DoesNotThrow_UsesEncryptedLookup()
     {
         _clientMock

--- a/Branta/V2/Services/BrantaService.cs
+++ b/Branta/V2/Services/BrantaService.cs
@@ -75,7 +75,7 @@ public class BrantaService(IBrantaClient client, IAesEncryption aesEncryption, I
     {
         var hashZkType = destinationValue.GetHashZkType();
 
-        if (hashZkType == null && _defaultOptions.GetPrivacy(options) == PrivacyMode.Strict)
+        if (hashZkType == null && destinationEncryptionKey == null && _defaultOptions.GetPrivacy(options) == PrivacyMode.Strict)
             throw new BrantaPaymentException("PrivacyMode.Strict does not permit plain-text lookups for this destination type.");
 
         var normalizedDestination = hashZkType.HasValue ? destinationValue.ToLowerInvariant() : destinationValue;


### PR DESCRIPTION
Closes #53 